### PR TITLE
Add support for Humble

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,8 @@ find_package(builtin_interfaces REQUIRED)
 find_package(px4_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
 
-include_directories(include)
+include_directories(include
+${EIGEN3_INCLUDE_DIR})
 
 set(DEPS
 rclcpp

--- a/include/allan_ros2/write.hpp
+++ b/include/allan_ros2/write.hpp
@@ -6,7 +6,7 @@
 #include <iomanip>
 
 
-namespace write {
+namespace allan_write {
     struct AllanDeviationFormat {
         double period;
         double acc_x;

--- a/src/allan_node.cc
+++ b/src/allan_node.cc
@@ -18,11 +18,11 @@ namespace allan_ros {
     AllanNode::~AllanNode() {}
 
     void AllanNode::initialize_parameters() {
-        this->declare_parameter("topic");
-        this->declare_parameter("bag_path");
-        this->declare_parameter("publish_rate");
-        this->declare_parameter("sample_rate");
-        this->declare_parameter("msg_type");
+        this->declare_parameter("topic", "/imu");
+        this->declare_parameter("bag_path", "bag");
+        this->declare_parameter("publish_rate", 10);
+        this->declare_parameter("sample_rate", 10);
+        this->declare_parameter("msg_type", "ros");
     }
 
     void AllanNode::configure_parameters() {
@@ -70,9 +70,17 @@ namespace allan_ros {
         imu::sample_buffer.emplace_back(measurement);  
     }
 
+    static bool endsWith(std::string_view str, std::string_view suffix)
+	{
+		return str.size() >= suffix.size() && 0 == str.compare(str.size()-suffix.size(), suffix.size(), suffix);
+	}
+
     void AllanNode::process_bag() {
         bag_storage_options.uri = bag_path.as_string();
-        bag_storage_options.storage_id = "sqlite3";
+        if (endsWith(bag_path.as_string(), "mcap"))
+	        bag_storage_options.storage_id = "mcap";
+	    else
+	        bag_storage_options.storage_id = "sqlite3";
         
         bag_converter_options.input_serialization_format = rmw_get_serialization_format();
         bag_converter_options.output_serialization_format = rmw_get_serialization_format();

--- a/src/compute.cc
+++ b/src/compute.cc
@@ -84,7 +84,7 @@ namespace compute {
             allan_deviation = {std::sqrt(avar[0]), std::sqrt(avar[1]), std::sqrt(avar[2]),
                                                 std::sqrt(avar[3]), std::sqrt(avar[4]), std::sqrt(avar[5])};
 
-            write::allan_deviation(allan_deviation, period_time);
+            allan_write::allan_deviation(allan_deviation, period_time);
         }
 
     }

--- a/src/write.cc
+++ b/src/write.cc
@@ -1,7 +1,7 @@
 #include <iostream>
 #include "allan_ros2/write.hpp"
 
-namespace write {
+namespace allan_write {
     void allan_deviation(std::vector<double> deviation, double period) {
         AllanDeviationFormat deviation_format;
         deviation_format.period = period; 


### PR DESCRIPTION
Closes #1

In humble by default mcap is used for rosbag recording, added support for it also.
This shouldn't break Foxy and Galactic support.